### PR TITLE
Update Poetry Lock Commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
     -   id: poetry-check
     -   id: poetry-lock
+        args: ["--check"]
 -   repo: local
     hooks:
     -   id: black


### PR DESCRIPTION
# Description

Updates our pre-commit hook to run `poetry lock --check`, which should only check whether our `pyproject.toml` is in sync with our `poetry.lock`. It _should_ no longer update the lock file on every commit. See issue for more detail.

Fixes #13 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
