### PR TITLE
Fix Custom Datset Validation Failure

### DIFF
--- a/src/coin_test/data/datasets.py
+++ b/src/coin_test/data/datasets.py
@@ -2,7 +2,6 @@
 
 from abc import ABCMeta, abstractmethod
 from collections import Counter
-from datetime import datetime
 from typing import Any
 
 import pandas as pd
@@ -159,7 +158,7 @@ class CustomDataset(PriceDataset):
         elif series.dtype == int:
             # If int, assume time since epoch
             index = pd.PeriodIndex(
-                data=[datetime.fromtimestamp(d) for d in series],
+                data=pd.to_datetime(series, unit="s"),
                 freq=freq,  # type: ignore
             )
         else:
@@ -169,6 +168,7 @@ class CustomDataset(PriceDataset):
                 pandas PeriodIndex.
                 """
             )
+        df = df.drop(columns=[cls.OPEN_TIME_NAME])
         return df.set_index(index, verify_integrity=True)
 
     @property

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -104,6 +104,15 @@ def test_add_period_index(
         assert p == pd.Period(d, freq=freq)  # type: ignore
 
 
+def test_add_period_index_validation(hour_data_df: pd.DataFrame) -> None:
+    """Build valid dataframe with period index."""
+    dates = [datetime(2000, 1, 1), datetime(2001, 1, 1), datetime(2002, 1, 1)]
+    hour_data_df = hour_data_df[: len(dates)].copy()
+    hour_data_df["Open Time"] = pd.Series(dates)
+    df = CustomDataset._add_period_index(hour_data_df, "Y")
+    assert CustomDataset._validate_df(df)
+
+
 def test_init_custom_dataset(hour_data_df: pd.DataFrame, mocker: MockerFixture) -> None:
     """Initialize correctly."""
     pair = AssetPair(Ticker("BTC"), Ticker("USDT"))


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.-->

Fixes #24 

Previously, the process of generating a period index would take in a 'Open Time' column, but not delete it afterwards. Validation would then fail as extra columns outside the specified schema are disallowed.

This PR updates the `_add_period_index()` method to properly drop the 'Open Time' column, and adds an integration test to catch for this case in the future. It also includes a small change to use Pandas time inferences instead of datetime time inference.

## Type of change
<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
