### PR TITLE
Return timestamps from simulation

### DIFF
--- a/src/coin_test/backtest/simulator.py
+++ b/src/coin_test/backtest/simulator.py
@@ -189,7 +189,11 @@ class Simulator:
             trade_requests.extend(strat(time, portfolio, lookback_data))
         return trade_requests
 
-    def run(self) -> tuple[list[Portfolio], list[Trade], list[list[TradeRequest]]]:
+    def run(
+        self,
+    ) -> tuple[
+        list[pd.Timestamp], list[Portfolio], list[Trade], list[list[TradeRequest]]
+    ]:
         """Run a simulation."""
         schedule = [
             (s, croniter(s.schedule, self._start_time)) for s in self._strategies
@@ -204,6 +208,7 @@ class Simulator:
         historical_portfolios = [self._portfolio]
         historical_trades: list[Trade] = []
         historical_pending_orders: list[list[TradeRequest]] = []
+        historical_times: list[pd.Timestamp] = [self._start_time - self._simulation_dt]
 
         # State
         time = self._start_time
@@ -230,5 +235,11 @@ class Simulator:
             historical_trades.extend(executed_trades)
             historical_portfolios.append(portfolio)
             historical_pending_orders.append(copy(pending_orders))
+            historical_times.append(time)
             time += self._simulation_dt
-        return historical_portfolios, historical_trades, historical_pending_orders
+        return (
+            historical_times,
+            historical_portfolios,
+            historical_trades,
+            historical_pending_orders,
+        )

--- a/tests/backtest/test_simulator.py
+++ b/tests/backtest/test_simulator.py
@@ -315,10 +315,10 @@ def test_run(
 
     mock_composer = Mock()
     mock_composer.get_range.return_value = dict.fromkeys([asset_pair], None)
-    time = dt.datetime.now()
+    time = pd.Timestamp.now()
     type(mock_composer).start_time = PropertyMock(return_value=time)
     type(mock_composer).end_time = PropertyMock(
-        return_value=time + dt.timedelta(days=2)
+        return_value=time + pd.DateOffset(days=2)
     )
     type(mock_composer).freq = PropertyMock(return_value=pd.DateOffset(days=1))
     mock_composer.get_timestep.return_value = timestamp_asset_price
@@ -353,8 +353,13 @@ def test_run(
     # TODO: Thi should be refactored to be a mocked object
     sim = Simulator(mock_composer, portfolio, [strategy1, strategy2])
 
-    hist_port, hist_trades, hist_pending = sim.run()
+    hist_times, hist_port, hist_trades, hist_pending = sim.run()
 
+    assert hist_times == [
+        mock_composer.start_time - mock_composer.freq,
+        mock_composer.start_time,
+        mock_composer.start_time + mock_composer.freq,
+    ]
     assert hist_port == [portfolio, portfolio_handled, portfolio_handled]
     assert hist_trades == [
         mock_executed_trade.build_trade(),


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.-->

Fixes #31 

Updates the simulator's `run()` method to also return a list of timestamps the simulation ran on. This allows for analysis to better correlate the raw data and the strategy performance.

## Type of change
<!--Please delete options that are not relevant.-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
