### PR TITLE
Add string representations

### DIFF
--- a/src/coin_test/backtest/portfolio.py
+++ b/src/coin_test/backtest/portfolio.py
@@ -75,3 +75,7 @@ class Portfolio:
             adjusted_assets[asset] -= Money(asset, trade.amount)
 
         return Portfolio(self.base_currency, adjusted_assets)
+
+    def __repr__(self) -> str:
+        """Build string representation."""
+        return f"{self.base_currency} - {self.assets}"

--- a/src/coin_test/backtest/trade.py
+++ b/src/coin_test/backtest/trade.py
@@ -21,3 +21,17 @@ class Trade:
         self.side = side
         self.amount = amount
         self.price = price
+
+    def __repr__(self) -> str:
+        """Build string representation."""
+        currency_amt = self.amount * self.price
+        if self.side == Side.BUY:
+            return (
+                f"{currency_amt} {self.asset_pair.currency} -> "
+                f"{self.amount} {self.asset_pair.asset}"
+            )
+        else:
+            return (
+                f"{self.amount} {self.asset_pair.asset} -> "
+                f"{currency_amt} {self.asset_pair.currency}"
+            )

--- a/src/coin_test/util/money.py
+++ b/src/coin_test/util/money.py
@@ -55,3 +55,7 @@ class Money:
         self._check_compatibility(other)
 
         return Money(self.ticker, self.qty - other.qty)
+
+    def __repr__(self) -> str:
+        """Build string representation."""
+        return f'Money("{self.ticker}", {self.qty})'

--- a/src/coin_test/util/ticker.py
+++ b/src/coin_test/util/ticker.py
@@ -33,6 +33,10 @@ class Ticker:
         """Hash a ticker based on the symbol name."""
         return hash(self.symbol)
 
+    def __repr__(self) -> str:
+        """Build string representation."""
+        return f'Ticker("{self.symbol}")'
+
 
 class AssetPair(NamedTuple):
     """Pair of tickers that can be traded."""

--- a/tests/backtest/test_portfolio.py
+++ b/tests/backtest/test_portfolio.py
@@ -75,7 +75,7 @@ def _make_mock_trade(
     return mock_trade
 
 
-def test_adjustment_success_buy(assets: dict, asset_pair: AssetPair) -> None:
+def test_adjustment_success_buy(asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     trade = _make_mock_trade(asset_pair, Side.BUY, 10, 10.1)
 
@@ -101,7 +101,7 @@ def test_adjustment_success_buy(assets: dict, asset_pair: AssetPair) -> None:
     assert adj_portfolio.assets[asset_pair.asset] == exepcted_trade_currency
 
 
-def test_adjustment_failure_buy(assets: dict, asset_pair: AssetPair) -> None:
+def test_adjustment_failure_buy(asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     trade = _make_mock_trade(asset_pair, Side.BUY, 100, 10.1)
     portfolio_assets = {
@@ -115,7 +115,7 @@ def test_adjustment_failure_buy(assets: dict, asset_pair: AssetPair) -> None:
     assert adj_portfolio is None
 
 
-def test_adjustment_success_sell(assets: dict, asset_pair: AssetPair) -> None:
+def test_adjustment_success_sell(asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     trade = _make_mock_trade(asset_pair, Side.SELL, 1.5, 10)
     portfolio_assets = {
@@ -139,7 +139,7 @@ def test_adjustment_success_sell(assets: dict, asset_pair: AssetPair) -> None:
     assert adj_portfolio.assets[asset_pair.asset] == exepcted_trade_currency
 
 
-def test_adjustment_failure_sell(assets: dict, asset_pair: AssetPair) -> None:
+def test_adjustment_failure_sell(asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     trade = _make_mock_trade(asset_pair, Side.SELL, 1.52, 10)
     portfolio_assets = {
@@ -151,3 +151,10 @@ def test_adjustment_failure_sell(assets: dict, asset_pair: AssetPair) -> None:
     adj_portfolio = portfolio.adjust(trade)
 
     assert adj_portfolio is None
+
+
+def test_portfolio_repr(assets: dict) -> None:
+    """Builds string representation."""
+    base_currency = Ticker("USDT")
+    portfolio = Portfolio(base_currency, assets)
+    assert repr(portfolio) == f"{base_currency} - {assets}"

--- a/tests/backtest/test_trade.py
+++ b/tests/backtest/test_trade.py
@@ -4,9 +4,7 @@ from coin_test.backtest import Trade
 from coin_test.util import AssetPair, Side
 
 
-def test_trade(
-    asset_pair: AssetPair,
-) -> None:
+def test_trade(asset_pair: AssetPair) -> None:
     """Initialize correctly."""
     price = 100.0
     side = Side.BUY
@@ -18,3 +16,27 @@ def test_trade(
     assert x.side == side
     assert x.price == price
     assert x.amount == amount
+
+
+def test_trade_repr_buy(asset_pair: AssetPair) -> None:
+    """Build string representation for buy."""
+    price = 100.0
+    side = Side.BUY
+    amount = 9.7
+    currency_amount = price * amount
+    trade = Trade(asset_pair=asset_pair, side=side, price=price, amount=amount)
+    rep = repr(trade)
+    expected = f"{currency_amount} {asset_pair.currency} -> {amount} {asset_pair.asset}"
+    assert rep == expected
+
+
+def test_trade_repr_sell(asset_pair: AssetPair) -> None:
+    """Build string representation for sell."""
+    price = 100.0
+    side = Side.SELL
+    amount = 9.7
+    currency_amount = price * amount
+    trade = Trade(asset_pair=asset_pair, side=side, price=price, amount=amount)
+    rep = repr(trade)
+    expected = f"{amount} {asset_pair.asset} -> {currency_amount} {asset_pair.currency}"
+    assert rep == expected

--- a/tests/util/test_money.py
+++ b/tests/util/test_money.py
@@ -76,3 +76,11 @@ def test_invalid_comparison() -> None:
 
     with pytest.raises(ValueError):
         assert x > y
+
+
+def test_money_repr() -> None:
+    """Builds string representation."""
+    ticker = Ticker("BTC")
+    qty = 12.5
+    money = Money(ticker, qty)
+    assert repr(money) == f'Money("{ticker}", {qty})'

--- a/tests/util/test_ticker.py
+++ b/tests/util/test_ticker.py
@@ -55,3 +55,10 @@ def test_ticker_invalid_comparison() -> None:
     with pytest.raises(NotImplementedError):
         assert ticker != ticker2_symbol
         assert ticker2_symbol != ticker
+
+
+def test_ticker_repr() -> None:
+    """Builds string representation."""
+    symbol = "BTC"
+    ticker = Ticker(symbol)
+    assert repr(ticker) == f'Ticker("{symbol.lower()}")'


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.-->

Fixes #29 

Implements the `__repr__` dunder method for the `AssetPair`, `Ticker`, `Trade`, `TradeRequest` and `Money` types.

## Type of change
<!--Please delete options that are not relevant.-->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
