### PR TITLE
Add Slippage and Transaction Fees

### DIFF
--- a/src/coin_test/backtest/portfolio.py
+++ b/src/coin_test/backtest/portfolio.py
@@ -63,15 +63,23 @@ class Portfolio:
         asset = trade.asset_pair.asset
         if trade.side == Side.BUY:
             # Check for overspending
-            if adjusted_assets[currency] < Money(currency, trade.amount * trade.price):
+            if adjusted_assets[currency] < Money(
+                currency, trade.amount * trade.price + trade.transaction_fee
+            ):
                 return None
 
-            adjusted_assets[currency] -= Money(currency, trade.amount * trade.price)
+            adjusted_assets[currency] -= Money(
+                currency, trade.amount * trade.price + trade.transaction_fee
+            )
             adjusted_assets[asset] += Money(asset, trade.amount)
         else:
-            if adjusted_assets[asset] < Money(asset, trade.amount):
+            if adjusted_assets[asset] < Money(asset, trade.amount) or adjusted_assets[
+                currency
+            ] < Money(currency, trade.transaction_fee - trade.amount * trade.price):
                 return None
-            adjusted_assets[currency] += Money(currency, trade.amount * trade.price)
+            adjusted_assets[currency] += Money(
+                currency, trade.amount * trade.price - trade.transaction_fee
+            )
             adjusted_assets[asset] -= Money(asset, trade.amount)
 
         return Portfolio(self.base_currency, adjusted_assets)

--- a/src/coin_test/backtest/trade.py
+++ b/src/coin_test/backtest/trade.py
@@ -7,7 +7,12 @@ class Trade:
     """Store the details of a trade."""
 
     def __init__(
-        self, asset_pair: AssetPair, side: Side, amount: float, price: float
+        self,
+        asset_pair: AssetPair,
+        side: Side,
+        amount: float,
+        price: float,
+        transaction_fee: float = 0,
     ) -> None:
         """Initialize a Trade object.
 
@@ -16,8 +21,10 @@ class Trade:
             side: The direction of the trade
             amount: The number of shares of the asset
             price: The price per share of the asset
+            transaction_fee: The trasaction fee, always in the base currency
         """
         self.asset_pair = asset_pair
         self.side = side
         self.amount = amount
         self.price = price
+        self.transaction_fee = transaction_fee

--- a/src/coin_test/backtest/trade_request.py
+++ b/src/coin_test/backtest/trade_request.py
@@ -82,14 +82,7 @@ class TradeRequest(ABC):
             float: The slippage-adjusted rate for the transaction.
         """
         curr_price = current_asset_price[asset_pair]
-        average_price = mean(
-            (
-                curr_price["Open"].iloc[0],
-                curr_price["High"].iloc[0],
-                curr_price["Low"].iloc[0],
-                curr_price["Close"].iloc[0],
-            )
-        )
+        average_price = mean(curr_price[["Open", "High", "Low", "Close"]].iloc[0])
 
         BASIS_POINT_ADJ = 10
 

--- a/src/coin_test/backtest/trade_request.py
+++ b/src/coin_test/backtest/trade_request.py
@@ -55,7 +55,7 @@ class TradeRequest(ABC):
         """
 
     @abstractmethod
-    def build_trade(self, current_asset_price: float) -> Trade:
+    def build_trade(self, current_asset_price: dict[AssetPair, pd.DataFrame]) -> Trade:
         """Build Trade that represents a TradeRequest.
 
         Args:

--- a/src/coin_test/backtest/trade_request.py
+++ b/src/coin_test/backtest/trade_request.py
@@ -66,7 +66,7 @@ class TradeRequest(ABC):
         """
 
     @staticmethod
-    def apply_slippage(
+    def _calculate_slippage(
         asset_pair: AssetPair,
         side: Side,
         current_asset_price: dict[AssetPair, pd.DataFrame],
@@ -101,7 +101,7 @@ class TradeRequest(ABC):
         return transaction_price
 
     @staticmethod
-    def generate_transaction_fee(amount: float, adjusted_price: float) -> float:
+    def _generate_transaction_fee(amount: float, adjusted_price: float) -> float:
         """Generate a transaction fee for a given trade request.
 
         Args:
@@ -132,13 +132,15 @@ class MarketTradeRequest(TradeRequest):
         Returns:
             Trade that the TradeRequest represents
         """
-        price = self.apply_slippage(self.asset_pair, self.side, current_asset_price)
+        price = TradeRequest._calculate_slippage(
+            self.asset_pair, self.side, current_asset_price
+        )
 
         amount = self.qty
         if amount is None:
             amount = cast(float, self.notional) / price
 
-        transaction_fee = self.generate_transaction_fee(amount, price)
+        transaction_fee = TradeRequest._generate_transaction_fee(amount, price)
 
         return Trade(self.asset_pair, self.side, amount, price, transaction_fee)
 

--- a/tests/backtest/test_portfolio.py
+++ b/tests/backtest/test_portfolio.py
@@ -65,19 +65,22 @@ def test_for_wrong_asset(assets: dict) -> None:
 
 
 def _make_mock_trade(
-    asset_pair: AssetPair, side: Side, qty: float, price: float
+    asset_pair: AssetPair, side: Side, qty: float, price: float, transaction_fee: float
 ) -> Mock:
     mock_trade = Mock()
     type(mock_trade).asset_pair = PropertyMock(return_value=asset_pair)
     type(mock_trade).side = PropertyMock(return_value=side)
     type(mock_trade).amount = PropertyMock(return_value=qty)
     type(mock_trade).price = PropertyMock(return_value=price)
+    type(mock_trade).transaction_fee = PropertyMock(return_value=transaction_fee)
     return mock_trade
 
 
 def test_adjustment_success_buy(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
-    trade = _make_mock_trade(asset_pair, Side.BUY, 10, 10.1)
+    transaction_fee = 0.50
+
+    trade = _make_mock_trade(asset_pair, Side.BUY, 10, 10.1, transaction_fee)
 
     portfolio_assets = {
         Ticker("BTC"): Money(Ticker("BTC"), 1.51),
@@ -90,7 +93,7 @@ def test_adjustment_success_buy(assets: dict, asset_pair: AssetPair) -> None:
     adj_portfolio = portfolio.adjust(trade)
 
     exepcted_base_currency = portfolio.assets[asset_pair.currency]
-    exepcted_base_currency.qty -= trade.amount * trade.price
+    exepcted_base_currency.qty -= trade.amount * trade.price + transaction_fee
     exepcted_trade_currency = portfolio.assets[asset_pair.asset]
     exepcted_trade_currency.qty += trade.amount
 
@@ -103,7 +106,8 @@ def test_adjustment_success_buy(assets: dict, asset_pair: AssetPair) -> None:
 
 def test_adjustment_failure_buy(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
-    trade = _make_mock_trade(asset_pair, Side.BUY, 100, 10.1)
+    transaction_fee = 0.5
+    trade = _make_mock_trade(asset_pair, Side.BUY, 100, 10.1, transaction_fee)
     portfolio_assets = {
         Ticker("BTC"): Money(Ticker("BTC"), 1.51),
         Ticker("ETH"): Money(Ticker("ETH"), 2),
@@ -117,7 +121,8 @@ def test_adjustment_failure_buy(assets: dict, asset_pair: AssetPair) -> None:
 
 def test_adjustment_success_sell(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
-    trade = _make_mock_trade(asset_pair, Side.SELL, 1.5, 10)
+    transaction_fee = 0.50
+    trade = _make_mock_trade(asset_pair, Side.SELL, 1.5, 10, transaction_fee)
     portfolio_assets = {
         Ticker("BTC"): Money(Ticker("BTC"), 1.51),
         Ticker("ETH"): Money(Ticker("ETH"), 2),
@@ -128,7 +133,7 @@ def test_adjustment_success_sell(assets: dict, asset_pair: AssetPair) -> None:
     adj_portfolio = portfolio.adjust(trade)
 
     exepcted_base_currency = portfolio.assets[asset_pair.currency]
-    exepcted_base_currency.qty += trade.amount * trade.price
+    exepcted_base_currency.qty += trade.amount * trade.price - transaction_fee
     exepcted_trade_currency = portfolio.assets[asset_pair.asset]
     exepcted_trade_currency.qty -= trade.amount
 
@@ -141,7 +146,8 @@ def test_adjustment_success_sell(assets: dict, asset_pair: AssetPair) -> None:
 
 def test_adjustment_failure_sell(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
-    trade = _make_mock_trade(asset_pair, Side.SELL, 1.52, 10)
+    transaction_fee = 0.5
+    trade = _make_mock_trade(asset_pair, Side.SELL, 1.52, 10, transaction_fee)
     portfolio_assets = {
         Ticker("BTC"): Money(Ticker("BTC"), 1.51),
         Ticker("ETH"): Money(Ticker("ETH"), 2),

--- a/tests/backtest/test_portfolio.py
+++ b/tests/backtest/test_portfolio.py
@@ -157,3 +157,21 @@ def test_adjustment_failure_sell(assets: dict, asset_pair: AssetPair) -> None:
     adj_portfolio = portfolio.adjust(trade)
 
     assert adj_portfolio is None
+
+
+def test_fail_on_transaction_fees(assets: dict, asset_pair: AssetPair) -> None:
+    """Fail on an all-in buy trade because of transaction fees."""
+    transaction_fee = 0.5
+    # buy 1 BTC that costs all of our money
+    trade = _make_mock_trade(
+        asset_pair, Side.BUY, 1, assets[asset_pair.currency].qty, transaction_fee
+    )
+    # portfolio_assets = {
+    #     Ticker("BTC"): Money(Ticker("BTC"), 1.51),
+    #     Ticker("ETH"): Money(Ticker("ETH"), 2),
+    #     Ticker("USDT"): Money(Ticker("USDT"), 1000),
+    # }
+    portfolio = Portfolio(asset_pair.currency, assets)
+    adj_portfolio = portfolio.adjust(trade)
+
+    assert adj_portfolio is None

--- a/tests/backtest/test_portfolio.py
+++ b/tests/backtest/test_portfolio.py
@@ -108,12 +108,8 @@ def test_adjustment_failure_buy(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     transaction_fee = 0.5
     trade = _make_mock_trade(asset_pair, Side.BUY, 100, 10.1, transaction_fee)
-    portfolio_assets = {
-        Ticker("BTC"): Money(Ticker("BTC"), 1.51),
-        Ticker("ETH"): Money(Ticker("ETH"), 2),
-        Ticker("USDT"): Money(Ticker("USDT"), 1000),
-    }
-    portfolio = Portfolio(asset_pair.currency, portfolio_assets)
+
+    portfolio = Portfolio(asset_pair.currency, assets)
     adj_portfolio = portfolio.adjust(trade)
 
     assert adj_portfolio is None
@@ -123,12 +119,8 @@ def test_adjustment_success_sell(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     transaction_fee = 0.50
     trade = _make_mock_trade(asset_pair, Side.SELL, 1.5, 10, transaction_fee)
-    portfolio_assets = {
-        Ticker("BTC"): Money(Ticker("BTC"), 1.51),
-        Ticker("ETH"): Money(Ticker("ETH"), 2),
-        Ticker("USDT"): Money(Ticker("USDT"), 1000),
-    }
-    portfolio = Portfolio(asset_pair.currency, portfolio_assets)
+
+    portfolio = Portfolio(asset_pair.currency, assets)
     copy_portfolio = copy(portfolio)
     adj_portfolio = portfolio.adjust(trade)
 
@@ -148,12 +140,8 @@ def test_adjustment_failure_sell(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     transaction_fee = 0.5
     trade = _make_mock_trade(asset_pair, Side.SELL, 1.52, 10, transaction_fee)
-    portfolio_assets = {
-        Ticker("BTC"): Money(Ticker("BTC"), 1.51),
-        Ticker("ETH"): Money(Ticker("ETH"), 2),
-        Ticker("USDT"): Money(Ticker("USDT"), 1000),
-    }
-    portfolio = Portfolio(asset_pair.currency, portfolio_assets)
+
+    portfolio = Portfolio(asset_pair.currency, assets)
     adj_portfolio = portfolio.adjust(trade)
 
     assert adj_portfolio is None
@@ -166,11 +154,18 @@ def test_fail_on_transaction_fees(assets: dict, asset_pair: AssetPair) -> None:
     trade = _make_mock_trade(
         asset_pair, Side.BUY, 1, assets[asset_pair.currency].qty, transaction_fee
     )
-    # portfolio_assets = {
-    #     Ticker("BTC"): Money(Ticker("BTC"), 1.51),
-    #     Ticker("ETH"): Money(Ticker("ETH"), 2),
-    #     Ticker("USDT"): Money(Ticker("USDT"), 1000),
-    # }
+    portfolio = Portfolio(asset_pair.currency, assets)
+    adj_portfolio = portfolio.adjust(trade)
+
+    assert adj_portfolio is None
+
+
+def test_fail_on_transaction_fees_sell(assets: dict, asset_pair: AssetPair) -> None:
+    """Fail on an all-in buy trade because of transaction fees."""
+    # what a rip off
+    transaction_fee = 1e5
+    # buy 1 BTC that costs all of our money
+    trade = _make_mock_trade(asset_pair, Side.SELL, 1, 1, transaction_fee)
     portfolio = Portfolio(asset_pair.currency, assets)
     adj_portfolio = portfolio.adjust(trade)
 

--- a/tests/backtest/test_portfolio.py
+++ b/tests/backtest/test_portfolio.py
@@ -107,7 +107,7 @@ def test_adjustment_success_buy(assets: dict, asset_pair: AssetPair) -> None:
 def test_adjustment_failure_buy(assets: dict, asset_pair: AssetPair) -> None:
     """Adjust a portfolio."""
     transaction_fee = 0.5
-    trade = _make_mock_trade(asset_pair, Side.BUY, 100, 10.1, transaction_fee)
+    trade = _make_mock_trade(asset_pair, Side.BUY, 1000, 10.1, transaction_fee)
 
     portfolio = Portfolio(asset_pair.currency, assets)
     adj_portfolio = portfolio.adjust(trade)

--- a/tests/backtest/test_trade.py
+++ b/tests/backtest/test_trade.py
@@ -11,10 +11,18 @@ def test_trade(
     price = 100.0
     side = Side.BUY
     amount = 9.7
+    transaction_fee = 0.25
 
-    x = Trade(asset_pair=asset_pair, side=side, price=price, amount=amount)
+    x = Trade(
+        asset_pair=asset_pair,
+        side=side,
+        price=price,
+        amount=amount,
+        transaction_fee=transaction_fee,
+    )
 
     assert x.asset_pair == asset_pair
     assert x.side == side
     assert x.price == price
     assert x.amount == amount
+    assert x.transaction_fee == transaction_fee


### PR DESCRIPTION
- Add slippage and transaction fees
- Add tests for slippage and transaction fees

# Description

Add transaction fees (currently 0.5% or 50 basis points of the total value of the transaction)
and slippage (currently the average of OHLC data with a 0.1% or 10 basis points spread).

Fixes #25 (transaction fees), #26 (slippage)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Full test coverage via unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
