### PR TITLE
Orchestration function fixes

### DIFF
--- a/src/coin_test/data/datasets.py
+++ b/src/coin_test/data/datasets.py
@@ -154,8 +154,8 @@ class Dataset(metaclass=DatasetMetaclass):
         pre_df = self.df[:index]
         post_df = self.df[index:].tail(-1)
 
-        pre_dataset = Dataset._dataset_from_split(pre_df, self)
-        post_dataset = Dataset._dataset_from_split(post_df, self)
+        pre_dataset = self._dataset_from_split(pre_df, self)
+        post_dataset = self._dataset_from_split(post_df, self)
         return pre_dataset, post_dataset
 
     @staticmethod

--- a/src/coin_test/orchestration/orchestration.py
+++ b/src/coin_test/orchestration/orchestration.py
@@ -95,7 +95,7 @@ def _gen_multiprocessed(
     main_to_worker = Queue()
     worker_to_main = Queue()
 
-    ctx = multiprocessing.get_context("spawn")
+    ctx = multiprocessing.get_context("fork")
     processes = [
         ctx.Process(
             target=_run_agent,

--- a/src/coin_test/orchestration/orchestration.py
+++ b/src/coin_test/orchestration/orchestration.py
@@ -106,7 +106,6 @@ def _gen_multiprocessed(
                 tx_calculator,
                 starting_portfolio,
                 backtest_length,
-                output_folder,
             ),
             daemon=True,
         )

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -179,15 +179,15 @@ def test_validate_split_valid_timestamp_index(
     valid_index = pd.Timestamp("2022-09-28T11")
 
     mocker.patch("coin_test.data.Dataset._calculate_split_index")
-    mocker.patch("coin_test.data.Dataset._dataset_from_split")
+    mocker.patch("coin_test.data.CustomDataset._dataset_from_split")
     Dataset._calculate_split_index.return_value = valid_index
-    Dataset._dataset_from_split.return_value = mock_datasets
+    CustomDataset._dataset_from_split.return_value = mock_datasets
 
     pre_df = dataset.df[:valid_index]
     post_df = dataset.df[valid_index:].tail(-1)
     pre, post = dataset.split()
 
-    call_args = Dataset._dataset_from_split.call_args_list
+    call_args = CustomDataset._dataset_from_split.call_args_list
     pd.testing.assert_frame_equal(pre_df, call_args[0][0][0])
     pd.testing.assert_frame_equal(post_df, call_args[1][0][0])
     assert call_args[0][0][1] == dataset
@@ -208,15 +208,15 @@ def test_validate_split_valid_integer_index(
     dataset = CustomDataset(hour_data_indexed_df, freq, pair)
 
     mocker.patch("coin_test.data.Dataset._calculate_split_index")
-    mocker.patch("coin_test.data.Dataset._dataset_from_split")
+    mocker.patch("coin_test.data.CustomDataset._dataset_from_split")
     Dataset._calculate_split_index.return_value = valid_index
-    Dataset._dataset_from_split.return_value = mock_datasets
+    CustomDataset._dataset_from_split.return_value = mock_datasets
 
     pre_df = dataset.df[:valid_index]
     post_df = dataset.df[valid_index:].tail(-1)
     pre, post = dataset.split()
 
-    call_args = Dataset._dataset_from_split.call_args_list
+    call_args = CustomDataset._dataset_from_split.call_args_list
     pd.testing.assert_frame_equal(pre_df, call_args[0][0][0])
     pd.testing.assert_frame_equal(post_df, call_args[1][0][0])
     assert call_args[0][0][1] == dataset

--- a/tests/orchestration/test_orchestration.py
+++ b/tests/orchestration/test_orchestration.py
@@ -174,7 +174,7 @@ def test_gen_multiprocessed(mocker: MockerFixture) -> None:
         datasets, strategies, sc, tc, portfolio, length, n_parallel, output_folder
     )
 
-    orc.multiprocessing.get_context.assert_called_once_with("spawn")
+    orc.multiprocessing.get_context.assert_called_once_with("fork")
     assert len(mock_ctx.Process.call_args_list) == n_parallel
     process_calls = [
         call(
@@ -186,7 +186,6 @@ def test_gen_multiprocessed(mocker: MockerFixture) -> None:
                 tc,
                 portfolio,
                 length,
-                output_folder,
             ),
             daemon=True,
         )


### PR DESCRIPTION
# Description

Fixes for several runtime errors.
* An additional argument was being passed when spawning new processes in orchestration.
* Orchestration uses `fork` instead of `spawn` for new processes.
* The split() method referenced `Dataset` instead of `self`.

## Type of change
<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
