### PR TITLE
Build datapane from saved results via `orchestration.run()`

### DIFF
--- a/src/coin_test/backtest/backtest_results.py
+++ b/src/coin_test/backtest/backtest_results.py
@@ -104,3 +104,22 @@ class BacktestResults:
             total += conversion * money.qty
 
         return total
+
+    @staticmethod
+    def load(fp: str) -> "BacktestResults":
+        """Load BacktestResults from disk.
+
+        Args:
+            fp: filepath to pickle file to load from
+
+        Returns:
+            BacktestResults: BacktestResults stored at the location
+
+        Raises:
+            ValueError: raises ValueError if the specified file path is not a file
+        """
+        if not os.path.isfile(fp):
+            raise ValueError(f"'{fp}' is not a file.")
+
+        with open(fp, "rb") as f:
+            return pickle.load(f)

--- a/src/coin_test/backtest/backtest_results.py
+++ b/src/coin_test/backtest/backtest_results.py
@@ -71,6 +71,7 @@ class BacktestResults:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "wb") as f:
             pickle.dump(self, f)
+        logger.debug(f"Saved pickled BacktestResults to: {path}")
 
     @staticmethod
     def create_date_price_df(sim_data: pd.DataFrame, composer: Composer) -> pd.Series:
@@ -122,4 +123,6 @@ class BacktestResults:
             raise ValueError(f"'{fp}' is not a file.")
 
         with open(fp, "rb") as f:
-            return pickle.load(f)
+            obj = pickle.load(f)
+            logger.debug(f"Loaded Backtest results from {fp}")
+            return obj

--- a/src/coin_test/data/datasaver.py
+++ b/src/coin_test/data/datasaver.py
@@ -1,8 +1,12 @@
 """Define the Datasaver class."""
+import logging
 import os
 import pickle
 
 from .datasets import Dataset
+
+
+logger = logging.getLogger(__name__)
 
 
 class Datasaver:
@@ -39,6 +43,7 @@ class Datasaver:
         path = os.path.join(directory, self.name + ".pkl")
         with open(path, "wb") as outp:
             pickle.dump(self, outp, pickle.HIGHEST_PROTOCOL)
+        logger.debug(f"Saved pickled Datasaver to: {path}")
         return path
 
     @staticmethod
@@ -58,4 +63,6 @@ class Datasaver:
             raise ValueError(f"'{fp}' is not a file.")
 
         with open(fp, "rb") as f:
-            return pickle.load(f)
+            obj = pickle.load(f)
+            logger.debug(f"Loaded Datasaver from {fp}")
+            return obj

--- a/src/coin_test/data/datasaver.py
+++ b/src/coin_test/data/datasaver.py
@@ -50,6 +50,12 @@ class Datasaver:
 
         Returns:
             Datasaver: Datasaver stored at the location
+
+        Raises:
+            ValueError: raises ValueError if the specified file path is not a file
         """
+        if not os.path.isfile(fp):
+            raise ValueError(f"'{fp}' is not a file.")
+
         with open(fp, "rb") as f:
             return pickle.load(f)

--- a/src/coin_test/orchestration/orchestration.py
+++ b/src/coin_test/orchestration/orchestration.py
@@ -1,4 +1,5 @@
 """Define the orchestration function."""
+import logging
 import multiprocessing
 from multiprocessing import Queue
 import os
@@ -20,6 +21,9 @@ from ..backtest import (
     TransactionFeeCalculator,
 )
 from ..data import Composer, PriceDataset
+
+
+logger = logging.getLogger(__name__)
 
 
 def _save(result: BacktestResults, output_folder: str | None, i: int) -> None:
@@ -44,6 +48,7 @@ def _load(
     if len(results) == 0:
         raise ValueError(f"No backtest results found in {input_dir}")
 
+    logger.info(f"Loaded {len(results)}BacktestResults from {input_dir}.")
     return results
 
 
@@ -261,6 +266,9 @@ def run(
             args must be provided to run a backtest
     """
     if build_from_saved_results is not None:
+        logger.info(
+            f"Building analysis from saved results from: {build_from_saved_results}"
+        )
         results = _load(build_from_saved_results)
 
     else:
@@ -277,9 +285,13 @@ def run(
 
         if slippage_calculator is None:
             slippage_calculator = ConstantSlippage()
+            logger.info("Backtesting with ConstantSlippage slippage.")
         if tx_calculator is None:
             tx_calculator = ConstantTransactionFeeCalculator()
+            logger.info("Backtesting with ConstantTransactionFeeCalculator tx fees.")
 
+        if output_folder is None:
+            logger.info("BacktestResults are not being saved.")
         results = _gen_results(
             all_datasets,
             all_strategies,

--- a/src/coin_test/orchestration/orchestration.py
+++ b/src/coin_test/orchestration/orchestration.py
@@ -3,7 +3,7 @@ import multiprocessing
 from multiprocessing import Queue
 import os
 import traceback
-from typing import cast, Iterator, Sequence
+from typing import cast, Iterator, List, Sequence
 
 import pandas as pd
 from tqdm import tqdm
@@ -26,6 +26,25 @@ def _save(result: BacktestResults, output_folder: str | None, i: int) -> None:
     if output_folder is not None:
         fn = os.path.join(output_folder, f"{i}_backtest_results.pkl")
         result.save(fn)
+
+
+def _load(
+    input_dir: str,
+) -> List[BacktestResults]:
+    """Wrapper to load list of backtest of results."""
+    results: List[BacktestResults] = []
+
+    if not os.path.isdir(input_dir):
+        raise ValueError(f"'{input_dir}', is not a directory")
+
+    for file in os.listdir(input_dir):
+        if file.endswith(".pkl"):
+            results.append(BacktestResults.load(os.path.join(input_dir, file)))
+
+    if len(results) == 0:
+        raise ValueError(f"No backtest results found in {input_dir}")
+
+    return results
 
 
 def _run_backtest(
@@ -207,14 +226,15 @@ def _gen_results(
 
 
 def run(
-    all_datasets: Sequence[Sequence[PriceDataset]],
-    all_strategies: Sequence[Sequence[Strategy]],
-    starting_portfolio: Portfolio,
-    backtest_length: pd.Timedelta | pd.DateOffset,
+    all_datasets: Sequence[Sequence[PriceDataset]] | None = None,
+    all_strategies: Sequence[Sequence[Strategy]] | None = None,
+    starting_portfolio: Portfolio | None = None,
+    backtest_length: pd.Timedelta | None = None,
     n_parallel: int = 1,
     output_folder: str | None = None,
     slippage_calculator: SlippageCalculator | None = None,
     tx_calculator: TransactionFeeCalculator | None = None,
+    build_from_saved_results: None | str = None,
 ) -> list[BacktestResults]:
     """Run a full set of backtests.
 
@@ -231,25 +251,45 @@ def run(
             not saved to disk.
         slippage_calculator: Slippage calc to use in simulations. Defaults to Constant
         tx_calculator: Transaction calc to use in simulations. Defaults to Constant_tx
+        build_from_saved_results: Filepath to load saved results from.
 
     Returns:
         List: All results of backtests
-    """
-    if slippage_calculator is None:
-        slippage_calculator = ConstantSlippage()
-    if tx_calculator is None:
-        tx_calculator = ConstantTransactionFeeCalculator()
 
-    results = _gen_results(
-        all_datasets,
-        all_strategies,
-        slippage_calculator,
-        tx_calculator,
-        starting_portfolio,
-        backtest_length,
-        n_parallel,
-        output_folder,
-    )
+    Raises:
+        ValueError: If build_from_save_results isn't provided,
+            args must be provided to run a backtest
+    """
+    if build_from_saved_results is not None:
+        results = _load(build_from_saved_results)
+
+    else:
+        if (
+            all_datasets is None
+            or all_strategies is None
+            or starting_portfolio is None
+            or backtest_length is None
+        ):
+            raise ValueError(
+                "Must specify 'build_from_save_results' or all of: 'all_datasets',\
+                    all_strategies', 'starting_portfolio', and 'backtest_length'"
+            )
+
+        if slippage_calculator is None:
+            slippage_calculator = ConstantSlippage()
+        if tx_calculator is None:
+            tx_calculator = ConstantTransactionFeeCalculator()
+
+        results = _gen_results(
+            all_datasets,
+            all_strategies,
+            slippage_calculator,
+            tx_calculator,
+            starting_portfolio,
+            backtest_length,
+            n_parallel,
+            output_folder,
+        )
 
     build_datapane(results)
 

--- a/tests/backtest/test_backtest_results.py
+++ b/tests/backtest/test_backtest_results.py
@@ -2,9 +2,10 @@
 
 import os
 import pickle
-from unittest.mock import MagicMock, Mock, mock_open
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pandas as pd
+import pytest
 from pytest_mock import MockerFixture
 
 from coin_test.backtest import BacktestResults
@@ -143,3 +144,28 @@ def test_results_save(mocker: MockerFixture) -> None:
     results.save(test_file_name)
     os.makedirs.assert_called_once_with("test_dir", exist_ok=True)
     pickle.dump.assert_called()
+
+
+def test_backtestresults_load_good_file(mocker: MockerFixture) -> None:
+    """Load Pickled Backtest Results Load properly."""
+    datasaver = Mock()
+    valid_local_path = "a_valid_path/test.pkl"
+
+    mocker.patch("os.path.isfile")
+    os.path.isfile.return_value = True
+
+    mocker.patch("pickle.load")
+    pickle.load.return_value = datasaver
+
+    with patch("builtins.open", mock_open(read_data="data")):
+        test = BacktestResults.load(valid_local_path)
+        open.assert_called_with(valid_local_path, "rb")
+        pickle.load.assert_called()
+        assert test == datasaver
+
+
+def test_backtestresults_load_bad_file() -> None:
+    """Error on invalid file."""
+    valid_local_path = "a_valid_path/test.pkl"
+    with pytest.raises(ValueError):
+        _ = BacktestResults.load(valid_local_path)

--- a/tests/data/test_datasaver.py
+++ b/tests/data/test_datasaver.py
@@ -4,6 +4,7 @@ import os
 import pickle
 from unittest.mock import Mock, mock_open, patch
 
+import pytest
 from pytest_mock import MockerFixture
 
 from coin_test.data import Datasaver, Dataset
@@ -77,10 +78,21 @@ def test_datasaver_load(mocker: MockerFixture) -> None:
     datasaver = Mock()
     valid_local_path = "a_valid_path/test.pkl"
 
+    mocker.patch("os.path.isfile")
+    os.path.isfile.return_value = True
+
     mocker.patch("pickle.load")
     pickle.load.return_value = datasaver
 
     with patch("builtins.open", mock_open(read_data="data")):
         test = Datasaver.load(valid_local_path)
+        open.assert_called_with(valid_local_path, "rb")
         pickle.load.assert_called()
         assert test == datasaver
+
+
+def test_datasaver_load_bad_file() -> None:
+    """Error on invalid file."""
+    valid_local_path = "a_valid_path/test.pkl"
+    with pytest.raises(ValueError):
+        _ = Datasaver.load(valid_local_path)


### PR DESCRIPTION
# Description
We added support to save results, this adds support to build datapane/analysis from those results. Fixes: #89 

Future work includes validation of these `BacktestResults` are the same length etc.

<!--Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.-->

## Type of change
<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Unit tests in orchestration and `BacktestResults`
<!--Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
