### PR TITLE
Add AssetPair constructor

### DIFF
--- a/src/coin_test/util/ticker.py
+++ b/src/coin_test/util/ticker.py
@@ -43,3 +43,26 @@ class AssetPair(NamedTuple):
 
     asset: Ticker
     currency: Ticker
+
+    @classmethod
+    def from_string(cls, tickers: str) -> "AssetPair":
+        """Create an AssetPair from a string with tickers.
+
+        For example, for a BTC to USDT AssetPair, run
+        >>>  AssetPair.from_string("BTC USDT")
+
+        Args:
+            tickers: A string of two tickers separated by a space
+
+        Returns:
+            AssetPair: The generated AssetPair
+
+        Raises:
+            ValueError: If the string cannot be parsed properly
+        """
+        try:
+            asset_str, currency_str = tickers.split(" ")
+        except ValueError as e:
+            raise ValueError("Invalid string of tickers") from e
+
+        return cls(Ticker(asset_str), Ticker(currency_str))

--- a/tests/util/test_ticker.py
+++ b/tests/util/test_ticker.py
@@ -3,6 +3,7 @@
 import pytest
 
 from coin_test.util import Ticker
+from coin_test.util.ticker import AssetPair
 
 
 def test_ticker() -> None:
@@ -62,3 +63,25 @@ def test_ticker_repr() -> None:
     symbol = "BTC"
     ticker = Ticker(symbol)
     assert repr(ticker) == f'Ticker("{symbol.lower()}")'
+
+
+def test_asset_pair_from_string() -> None:
+    """Creates an AssetPair from string."""
+    btc = Ticker("BTC")
+    usdt = Ticker("USDT")
+    ticker_impl = AssetPair(btc, usdt)
+
+    str_btc, str_usdt = str_impl = AssetPair.from_string("BTC USDT")
+
+    assert str_btc == btc
+    assert str_usdt == usdt
+    assert str_impl == ticker_impl
+
+
+def test_asset_pair_invalid_parse() -> None:
+    """Errors on bad string for AssetPair."""
+    bad_strings = ("BTCUSDT", "BTC ETH USDT", "BTC/USDT")
+
+    for bs in bad_strings:
+        with pytest.raises(ValueError):
+            AssetPair.from_string(bs)


### PR DESCRIPTION
# Description

Create a constructor for AssetPairs that is less syntax heavy

Now, the following syntax works:

```python
btc, usdt = btcusdt = AssetPair.from_string("BTC USDT")
```

Should the method name `from_string` be shorter? I can refactor it.

Fixes #99

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
